### PR TITLE
fix: Cover image is no longer returned by image tag if set to an empty, blank, or nil value

### DIFF
--- a/lib/jekyll-post-image-generator.rb
+++ b/lib/jekyll-post-image-generator.rb
@@ -5,6 +5,7 @@ require 'jekyll-post-image-generator/image_generator'
 require 'jekyll-post-image-generator/site_processor'
 require 'jekyll-post-image-generator/generator'
 require 'jekyll-post-image-generator/image_tag'
+require 'jekyll-post-image-generator/utils'
 
 module Jekyll
   module JekyllPostImageGenerator

--- a/lib/jekyll-post-image-generator/image_tag.rb
+++ b/lib/jekyll-post-image-generator/image_tag.rb
@@ -10,7 +10,7 @@ module Jekyll
 
       return nil if post.nil?
 
-      return post.data['cover_image'] if post.data.key?('cover_image')
+      return post.data['cover_image'] if set?('cover_image', post.data)
 
       image_path = create_path(output_dir(site.config), post)
 

--- a/lib/jekyll-post-image-generator/site_processor.rb
+++ b/lib/jekyll-post-image-generator/site_processor.rb
@@ -54,10 +54,6 @@ module Jekyll
         && (set?('title', data) || set?('cover_image_text', data)) \
         && !File.exist?(output_path(doc.basename_without_ext))
       end
-
-      def set?(key, data)
-        data.key?(key) && !data[key].nil? && !data[key].strip.empty?
-      end
     end
   end
 end

--- a/lib/jekyll-post-image-generator/utils.rb
+++ b/lib/jekyll-post-image-generator/utils.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def set?(key, data)
+  data.key?(key) && !data[key].nil? && !data[key].strip.empty?
+end

--- a/spec/image_tag_spec.rb
+++ b/spec/image_tag_spec.rb
@@ -33,6 +33,47 @@ describe(Jekyll::JekyllPostImageGenerator::ImageGenerator) do
         file.unlink
       end
     end
+
+    RSpec.shared_examples 'no cover image' do |value|
+      it 'should not return path to cover image' do
+        site = Site.new(source_dir)
+        output_dir = Jekyll::JekyllPostImageGenerator::DEFAULTS['output_directory']
+        expanded = File.expand_path(output_dir)
+        FileUtils.mkdir_p(expanded)
+        file = Tempfile.new(['', '.jpg'], expanded)
+
+        begin
+          file.close
+          path = file.path
+          raise('Temp file not created properly') if path.nil?
+
+          name = File.basename(path)
+          doc = Document.new(name[0...-4], "#{source_dir}/#{name}")
+          doc.data = doc.data.merge({ 'title' => 'test', 'cover_image' => value })
+          site.posts.docs << doc
+          parse_context = Liquid::ParseContext.new
+          parse_context.line_number = 1
+          image_tag = Jekyll::ImageTag.parse('', '', '', parse_context)
+          context = Context.new({ :site => site }, { 'page' => { 'path' => "#{source_dir}/#{name}" } }) # rubocop:disable Style/HashSyntax
+
+          expect(image_tag.render(context)).not_to eql(value)
+        ensure
+          file.unlink
+        end
+      end
+    end
+  end
+
+  context 'when empty cover image is set' do
+    include_examples('no cover image', '')
+  end
+
+  context 'when nil cover image is set' do
+    include_examples('no cover image', nil)
+  end
+
+  context 'when blank cover image is set' do
+    include_examples('no cover image', '  ')
   end
 
   context 'when post image is not rendered' do


### PR DESCRIPTION
Fixes an issue where the image tag returns the cover image when set to `''`, `'  '`, and `null`